### PR TITLE
feat: :sparkles: Add test login form, home and attestation tabs

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,0 +1,35 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Tabs } from "expo-router";
+import React from "react";
+
+const TabsLayout = () => {
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: "#4169E1",
+      }}
+    >
+      <Tabs.Screen
+        name="home"
+        options={{
+          tabBarLabel: "Home",
+          tabBarIcon: ({ color }) => (
+            <Ionicons name="home-outline" size={24} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="attestations"
+        options={{
+          tabBarLabel: "Attestations",
+          tabBarIcon: ({ color }) => (
+            <Ionicons name="document-text-outline" size={24} color={color} />
+          ),
+        }}
+      />
+    </Tabs>
+  );
+};
+
+export default TabsLayout;

--- a/app/(tabs)/attestations.tsx
+++ b/app/(tabs)/attestations.tsx
@@ -1,0 +1,10 @@
+import SafeAreaContent from "@/components/SafeAreaContent";
+import { Text } from "react-native";
+
+export default function Attestations() {
+  return (
+    <SafeAreaContent>
+      <Text>Attestations</Text>
+    </SafeAreaContent>
+  );
+}

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -1,0 +1,10 @@
+import SafeAreaContent from "@/components/SafeAreaContent";
+import { Text } from "react-native";
+
+export default function Home() {
+  return (
+    <SafeAreaContent>
+      <Text>Home page</Text>
+    </SafeAreaContent>
+  );
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ export default function RootLayout() {
   return (
     <QueryClientProvider client={queryClient}>
       <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="index" options={{ headerShown: false }} />
       </Stack>
     </QueryClientProvider>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,17 +1,11 @@
-import { useCountries } from "@/api/country/get-countries";
-import CountryForm from "@/components/CountryForm";
-import LocationDisplay from "@/components/LocationDisplay";
+import LoginForm from "@/components/LoginForm";
 import SafeAreaContent from "@/components/SafeAreaContent";
 
 import { StatusBar } from "expo-status-bar";
-import { AnimatePresence, View as MotiView } from "moti";
 import React from "react";
-import { FlatList, Text, View } from "react-native";
+import { Text, View } from "react-native";
 
 const App = () => {
-  const { data, isLoading, error } = useCountries();
-  if (error && !isLoading) console.log({ error });
-
   return (
     <SafeAreaContent>
       <View>
@@ -20,31 +14,9 @@ const App = () => {
           Removing plastic from the ocean, one fisherman's boat at a time.
         </Text>
       </View>
-      <LocationDisplay />
+      <LoginForm />
 
-      {isLoading && <Text>Loading countries...</Text>}
-      {error && <Text>Error loading countries: {error.message}</Text>}
-      {data && (
-        <AnimatePresence>
-          <FlatList
-            data={data.Country}
-            keyExtractor={(item) => item.id.toString()}
-            renderItem={({ item, index }) => (
-              <MotiView
-                from={{ opacity: 0, translateX: -10 }}
-                animate={{ translateX: 0, opacity: 1 }}
-                exit={{ opacity: 0, translateX: -10 }}
-                transition={{ delay: index * 60, type: "spring" }}
-                className="mt-4 text-base"
-              >
-                <Text className="font-bold text-lg">{item.Country}</Text>
-              </MotiView>
-            )}
-          />
-        </AnimatePresence>
-      )}
-      <CountryForm />
-      <StatusBar style="light" />
+      <StatusBar style="dark" />
     </SafeAreaContent>
   );
 };

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,0 +1,103 @@
+import { useForm } from "@tanstack/react-form";
+import { zodValidator } from "@tanstack/zod-form-adapter";
+import { router } from "expo-router";
+import { Pressable, Text, TextInput, View } from "react-native";
+import { z } from "zod";
+
+const LoginData = z.object({
+  email: z.string().email(),
+  password: z.string(),
+});
+
+type LoginData = z.infer<typeof LoginData>;
+
+export default function LoginForm() {
+  const form = useForm<LoginData>({
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+    onSubmit: async ({ value }) => {
+      if (value.email === "test@test.com" && value.password === "test") {
+        console.log("Login successful");
+        router.replace("/home");
+      } else {
+        console.log("Login failed");
+      }
+    },
+  });
+
+  return (
+    <View>
+      <Text className="font-bold text-lg">Login</Text>
+      <form.Field
+        name="email"
+        validators={{
+          onChange: z.string().trim().min(1, "Please enter your email"),
+        }}
+        validatorAdapter={zodValidator()}
+      >
+        {(field) => (
+          <>
+            <Text>Name</Text>
+            <TextInput
+              autoCapitalize="words"
+              keyboardType="default"
+              value={field.state.value}
+              onChangeText={field.handleChange}
+              onBlur={field.handleBlur}
+              className={`border py-2 px-3 rounded-lg ${
+                field.state.meta.errors.length > 0
+                  ? "border-red-600"
+                  : "border-slate-800"
+              }`}
+            />
+            {field.state.meta.errors.length > 0 ? (
+              <Text className="text-red-600 font-semibold">
+                {field.state.meta.errors.join(", ")}
+              </Text>
+            ) : null}
+          </>
+        )}
+      </form.Field>
+
+      <form.Field
+        name="password"
+        validators={{
+          onChange: z.string().trim().min(1, "Please enter your password"),
+        }}
+        validatorAdapter={zodValidator()}
+      >
+        {(field) => (
+          <>
+            <Text>Password</Text>
+            <TextInput
+              secureTextEntry={true}
+              autoCapitalize="none"
+              keyboardType="default"
+              value={field.state.value}
+              onChangeText={field.handleChange}
+              onBlur={field.handleBlur}
+              className={`border py-2 px-3 rounded-lg ${
+                field.state.meta.errors.length > 0
+                  ? "border-red-600"
+                  : "border-slate-800"
+              }`}
+            />
+            {field.state.meta.errors.length > 0 ? (
+              <Text className="text-red-600 font-semibold">
+                {field.state.meta.errors.join(", ")}
+              </Text>
+            ) : null}
+          </>
+        )}
+      </form.Field>
+      <Pressable
+        onPress={() => form.handleSubmit()}
+        className="flex flex-row items-center justify-center px-2 py-3 mt-2 bg-blue-700 rounded-md"
+      >
+        <Text className="text-white font-bold">Login</Text>
+      </Pressable>
+    </View>
+  );
+}


### PR DESCRIPTION
# Add login form and tab navigation structure

## Key Changes
- Added tab-based navigation with Home and Attestations screens
- Implemented login form with email/password validation
- Set up basic screen layouts and routing structure

## Detailed Changes

### Commits
- [a06681a7](https://github.com/Enaleia/mobile/commit/a06681a7124febca6d21fc6d2fa1cebbd65ebaf9) - Add login form, home and attestation tabs

### New Files
- `app/(tabs)/_layout.tsx` - Tab navigation configuration
- `app/(tabs)/attestations.tsx` - Attestations tab screen
- `app/(tabs)/home.tsx` - Home tab screen
- `components/LoginForm.tsx` - Login form with validation

### Modified Files
- `app/_layout.tsx` - Added tab screen configuration
- `app/index.tsx` - Replaced country listing with login form

### Dependencies Used
- `@tanstack/react-form` - Form handling
- `@tanstack/zod-form-adapter` - Form validation
- `expo-router` - Navigation
- `zod` - Type validation

### Testing Notes
Default test credentials:
- Email: test@test.com
- Password: test