### PR TITLE
feat: :sparkles: Add Information modal for attestations

### DIFF
--- a/app/attest/new/[type].tsx
+++ b/app/attest/new/[type].tsx
@@ -3,11 +3,12 @@ import { IncompleteAttestationModal } from "@/components/features/attest/Incompl
 import { LeaveAttestationModal } from "@/components/features/attest/LeaveAttestationModal";
 import MaterialSection from "@/components/features/attest/MaterialSection";
 import { SentToQueueModal } from "@/components/features/attest/SentToQueueModal";
+import TypeInformationModal from "@/components/features/attest/TypeInformationModal";
 import FormSection from "@/components/shared/FormSection";
 import SafeAreaContent from "@/components/shared/SafeAreaContent";
 import { ACTION_SLUGS } from "@/constants/action";
 import { useMaterials } from "@/hooks/data/useMaterials";
-import { ActionTitle } from "@/types/action";
+import { ActionTitle, typeModalMap } from "@/types/action";
 import { MaterialDetail } from "@/types/material";
 import { Ionicons } from "@expo/vector-icons";
 import { useForm } from "@tanstack/react-form";
@@ -79,6 +80,8 @@ const NewActionScreen = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
+  const [isTypeInformationModalVisible, setIsTypeInformationModalVisible] =
+    useState(false);
 
   const { materialsData, isLoading: materialsLoading } = useMaterials();
 
@@ -194,7 +197,7 @@ const NewActionScreen = () => {
           accessibilityRole="image"
         />
       </View>
-      <View className="flex-row items-center justify-start pb-4">
+      <View className="flex-row items-center justify-between pb-4">
         <form.Subscribe selector={(state) => state.values}>
           {(values) => (
             <Pressable
@@ -218,7 +221,20 @@ const NewActionScreen = () => {
             </Pressable>
           )}
         </form.Subscribe>
+
+        <Pressable onPress={() => setIsTypeInformationModalVisible(true)}>
+          <Ionicons
+            name="information-circle-outline"
+            size={24}
+            color="#0D0D0D"
+          />
+        </Pressable>
       </View>
+      <TypeInformationModal
+        {...typeModalMap[title]}
+        isVisible={isTypeInformationModalVisible}
+        onClose={() => setIsTypeInformationModalVisible(false)}
+      />
       <Text className="text-3xl font-dm-bold text-enaleia-black tracking-[-1px] mb-2">
         {title}
       </Text>

--- a/components/features/attest/TypeInformationModal.tsx
+++ b/components/features/attest/TypeInformationModal.tsx
@@ -1,0 +1,98 @@
+import ModalBase from "@/components/shared/ModalBase";
+import { TypeInformationProps } from "@/types/action";
+import { View } from "moti";
+import React from "react";
+import { Image, Text } from "react-native";
+
+const TypeInformationModal = ({
+  icons,
+  title,
+  description,
+  incomingInstructions,
+  outgoingInstructions,
+  important,
+  notes,
+  isVisible,
+  onClose,
+}: TypeInformationProps) => {
+  return (
+    <ModalBase isVisible={isVisible} onClose={onClose}>
+      <Text className="text-2xl font-dm-bold text-enaleia-black tracking-[-1px] my-3">
+        {title}
+      </Text>
+      <View className="flex-row items-center justify-start gap-3">
+        {icons.map((icon, index) => (
+          <Image source={icon} className="w-14 h-14" key={index} />
+        ))}
+      </View>
+      <Text className="text-base font-dm-regular text-enaleia-black mt-2 tracking-[-0.5px]">
+        {description}
+      </Text>
+      <View className="mt-4">
+        <Text className="text-lg font-dm-bold text-enaleia-black tracking-[-1px]">
+          Creating a {title} Attestation
+        </Text>
+      </View>
+      {incomingInstructions.length > 0 && (
+        <View className="mt-2">
+          <Text className="text-base font-dm-bold text-enaleia-black tracking-[-1px] mb-2">
+            Incoming materials
+          </Text>
+          <View>
+            {incomingInstructions.map((instruction, index) => (
+              <Text
+                key={index}
+                className="text-sm text-enaleia-black/70 font-dm-regular"
+              >
+                {" "}
+                {index + 1}. {instruction}
+              </Text>
+            ))}
+          </View>
+        </View>
+      )}
+      {outgoingInstructions.length > 0 && (
+        <View className="mt-2">
+          <Text className="text-base font-dm-bold text-enaleia-black tracking-[-1px] mb-2">
+            Outgoing materials
+          </Text>
+
+          <View className="mb-1">
+            {outgoingInstructions.map((instruction, index) => (
+              <Text
+                key={index}
+                className="text-sm text-enaleia-black/70 font-dm-regular"
+              >
+                {index + 1}. {instruction}
+              </Text>
+            ))}
+          </View>
+        </View>
+      )}
+      <View className="mt-3 p-3 bg-blue-100 rounded-md">
+        {important && (
+          <View>
+            <Text className="text-base font-dm-bold tracking-[-0.5px] text-enaleia-black mb-1">
+              Important
+            </Text>
+            <Text className="text-sm text-enaleia-black/70 font-dm-regular">
+              {important}
+            </Text>
+          </View>
+        )}
+        {notes && (
+          <View className="mt-2">
+            <Text className="text-base font-dm-bold text-enaleia-black tracking-[-0.5px] mb-1">
+              Notes
+            </Text>
+            <Text className="text-sm text-enaleia-black/70 font-dm-regular">
+              {notes}
+            </Text>
+          </View>
+        )}
+      </View>
+    </ModalBase>
+  );
+};
+
+export default TypeInformationModal;

--- a/components/shared/ModalBase.tsx
+++ b/components/shared/ModalBase.tsx
@@ -9,17 +9,19 @@ import {
   View,
 } from "react-native";
 
+interface ModalBaseProps {
+  isVisible: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  canClose?: boolean;
+}
+
 export default function ModalBase({
   isVisible,
   onClose,
   children,
   canClose = true,
-}: {
-  isVisible: boolean;
-  onClose: () => void;
-  children: React.ReactNode;
-  canClose?: boolean;
-}) {
+}: ModalBaseProps) {
   return (
     <Modal
       visible={isVisible}
@@ -46,7 +48,7 @@ export default function ModalBase({
                 onPress={onClose}
                 className="h-10 w-10 absolute right-0 top-3"
               >
-                <Ionicons name="close" size={20} color="gray" />
+                <Ionicons name="close" size={24} color="gray" />
               </Pressable>
             )}
           </View>

--- a/types/action.ts
+++ b/types/action.ts
@@ -65,3 +65,157 @@ export const processActions = (actions: any[]): GroupedActions => {
 
   return groupedActions;
 };
+
+export interface TypeInformationProps {
+  icons: ImageSourcePropType[];
+  title:
+    | "Collection"
+    | "Collection Batch"
+    | "Sorting"
+    | "Manufacturing"
+    | "Washing"
+    | "Shredding"
+    | "Pelletizing";
+  description: string;
+  incomingInstructions: string[];
+  outgoingInstructions: string[];
+  important: string;
+  notes: string;
+  isVisible: boolean;
+  onClose: () => void;
+}
+
+const commonIncomingCopy = [
+  "Tap “Add Incoming” button.",
+  "Select the material type for the manufacturing process.",
+  "Scan the QR code of the incoming material batch or manually enter the code.",
+  "Enter the weight of the material.",
+  "Repeat for each additional incoming materials, if necessary.",
+];
+
+const commonOutgoingCopy = [
+  "Affix a new QR code sticker to the sorted outgoing material.",
+  "Tap “Add Outgoing” button.",
+  "Select the material for the sorted outgoing batch.",
+  "Scan the newly affixed QR code or manually enter the code.",
+  "Enter the weight of the sorted outgoing material.",
+  "Repeat for each outgoing materials.",
+];
+
+type ModalData = Pick<
+  TypeInformationProps,
+  | "title"
+  | "description"
+  | "incomingInstructions"
+  | "outgoingInstructions"
+  | "important"
+  | "notes"
+  | "icons"
+>;
+
+const modalData: ModalData[] = [
+  {
+    title: "Collection",
+    description:
+      "A collection batch is used for shipping a container of collections.",
+    incomingInstructions: commonIncomingCopy.slice(0, -1),
+    outgoingInstructions: [],
+    important:
+      "A collection attestation should not be used to enter multiple collections from multiple collectors at once. It is used for a single or multiple collections from the same collector at any given time.",
+    notes: "",
+    icons: [
+      ACTION_ICONS["Fishing for litter"],
+      ACTION_ICONS["Prevention"],
+      ACTION_ICONS["Beach cleanup"],
+      ACTION_ICONS["Ad-hoc"],
+    ],
+  },
+  {
+    title: "Collection Batch",
+    icons: [ACTION_ICONS["Batch"]],
+    description:
+      "A collection batch is used for shipping a container of collections.",
+    incomingInstructions: [],
+    outgoingInstructions: commonOutgoingCopy.slice(0, -1),
+    important:
+      "If the collection batch materials span multiple containers, multiple outgoing materials should be added in the same attestation rather than creating a new attestation for each, but each container requires its own new unique QR sticker.",
+    notes: "",
+  },
+  {
+    title: "Sorting",
+    icons: [ACTION_ICONS["Sorting"]],
+    description:
+      "A sorting attestation typically involves one incoming material and multiple outgoing materials, although multiple incoming materials can be entered/processed at the same time for operational efficiency.",
+    incomingInstructions: commonIncomingCopy,
+    outgoingInstructions: commonOutgoingCopy,
+    important:
+      "If your sorted outgoing material requires multiple bags or containers, please add one outgoing entry for each.",
+    notes:
+      "Example: After sorting, there are enough HDPE to fill 2 bags, each bag will have its own unique QR code sticker and each will also have its individual outgoing entry in the attestation.",
+  },
+  {
+    title: "Shredding",
+    icons: [ACTION_ICONS["Shredding"]],
+    description:
+      "A shredding attestation generally involves one incoming material and one outgoing material, but multiple incoming and outgoing materials can be entered/processed at the same time for operational efficiency.",
+    incomingInstructions: commonIncomingCopy,
+    outgoingInstructions: commonOutgoingCopy,
+    important:
+      "If your shredding process has multiple incoming bags/containers, each should have its own individual incoming entry. \n\n If the shredding process produces enough materials to fill multiple bags/containers, each should have its own unique QR sticker as well as outgoing entry.",
+    notes:
+      "Example: After shredding, there are enough HDPE to fill 2 bags, each bag will have its own unique QR code sticker and each will also have its individual outgoing entry in the attestation.",
+  },
+  {
+    title: "Washing",
+    icons: [ACTION_ICONS["Washing"]],
+    description:
+      "A washing attestation typically involves one incoming material and one outgoing material, but multiple incoming and outgoing materials can be entered/processed at the same time for operational efficiency.",
+    incomingInstructions: commonIncomingCopy,
+    outgoingInstructions: commonOutgoingCopy,
+    important:
+      "If your washing process has multiple incoming bags/containers, each should have its own individual incoming entry. \n\n If the washing process produces enough materials to fill multiple bags/containers, each should have its own unique QR sticker as well as outgoing entry.",
+    notes:
+      "Example: After washing, there are enough HDPE to fill 2 bags, each bag will have its own unique QR code sticker and each will also have its individual outgoing entry in the attestation.",
+  },
+  {
+    title: "Pelletizing",
+    icons: [ACTION_ICONS["Pelletizing"]],
+    description:
+      "A pelletizing attestation typically involves multiple incoming materials and multiple outgoing materials.",
+    incomingInstructions: commonIncomingCopy,
+    outgoingInstructions: commonOutgoingCopy.slice(0, -1),
+    important:
+      "If your pelletizing process has multiple incoming bags/containers, each should have its own individual incoming entry. \n\n If the pelletizing process produces enough materials to fill multiple bags/containers, each should have its own unique QR sticker as well as outgoing entry.",
+    notes:
+      "Example: After pelletizing, there are enough HDPE to fill 2 bags, each bag will have its own unique QR code sticker and each will also have its individual outgoing entry in the attestation.",
+  },
+  {
+    title: "Manufacturing",
+    icons: [ACTION_ICONS["Manufacturing"]],
+    description:
+      "A manufacturing attestation possibly involves multiple incoming materials and batch information for the manufactured products.",
+    incomingInstructions: commonIncomingCopy,
+    outgoingInstructions: [
+      "Select the manufactured product.",
+      "Enter the batch quantity.",
+      "Enter the weight per item.",
+    ],
+    important:
+      "If your manufacturing process has multiple incoming bags/containers, each should have its own individual incoming entry.",
+    notes:
+      "Weight per item is the weight of a single item in the manufactured batch, it represents the average weight of each individual item in the batch.",
+  },
+];
+
+export const typeModalMap: Record<ActionTitle, ModalData> = {
+  "Fishing for litter": modalData[0],
+  Prevention: modalData[0],
+  "Beach cleanup": modalData[0],
+  "Ad-hoc": modalData[0],
+  Batch: modalData[1],
+  Sorting: modalData[2],
+  Shredding: modalData[3],
+  Washing: modalData[4],
+  Pelletizing: modalData[5],
+  Manufacturing: modalData[6],
+};


### PR DESCRIPTION
## Key changes
- Added new TypeInformationModal component to display detailed information about different attestation types
- Added info icon button to attestation screen header
- Added type definitions and content mapping for different attestation types

## Detailed changes

### New files
- `components/features/attest/TypeInformationModal.tsx`: New modal component for displaying attestation type information
- Added `TypeInformationProps` interface and `typeModalMap` in `types/action.ts`

### Modified files
- `app/attest/new/[type].tsx`: Added info button and modal integration
- `components/shared/ModalBase.tsx`: Added TypeScript interface and increased close icon size
- `types/action.ts`: Added type definitions and content mapping

### Commits
- [8c7dcd2](https://github.com/Enaleia/mobile/commit/8c7dcd2f2e399c19a91b7d2593c4520eea956765) feat: Add Information modal for attestations

The modal provides contextual help for users creating different types of attestations, including:
- Description of the attestation type
- Step-by-step instructions for incoming/outgoing materials
- Important notes and considerations
- Visual indicators (icons)