### PR TITLE
Sensible env. variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Make sure you have a .env file with the following content:
 
    QUEUE_PROCESSOR_INTERVAL=10000
    EXPO_PUBLIC_CACHE_KEY=enaleia-cache-v0
-   EXPO_PUBLIC_QUEUE_CACHE_KEY=enaleia-queue-v0
+   EXPO_PUBLIC_BATCH_CACHE_KEY=@enaleia-batch
+   EXPO_PUBLIC_ACTIVE_QUEUE_CACHE_KEY=@enaleia-queue/active
+   EXPO_PUBLIC_COMPLETED_QUEUE_CACHE_KEY=@enaleia-queue/completed
 ```
 
 ## Get started

--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
 
 Make sure you have a .env file with the following content:
 ```
-   EXPO_PUBLIC_API_URL = https://hq.enaleia.dev
+   EXPO_PUBLIC_API_URL=https://hq.enaleia-hub.com/
+
+   # Uncomment the following line for dev. environment
+   # NODE_ENV=development
+
+   QUEUE_PROCESSOR_INTERVAL=10000
+   EXPO_PUBLIC_CACHE_KEY=enaleia-cache-v0
+   EXPO_PUBLIC_QUEUE_CACHE_KEY=enaleia-queue-v0
 ```
 
 ## Get started

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ The Enaleia Hub mobile app is designed with the users’ physical and digital co
 
 This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
 
+## Environment
+
+Make sure you have a .env file with the following content:
+```
+   EXPO_PUBLIC_API_URL = https://hq.enaleia.dev
+```
+
 ## Get started
 
 1. Install dependencies

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",
-    "start-new": "EXPO_PUBLIC_CACHE_KEY=$(date +%s) expo start",
+    "start-new": "EXPO_PUBLIC_CACHE_KEY=$(date +%s) EXPO_PUBLIC_QUEUE_CACHE_KEY=$(date +%s) expo start",
     "reset-project": "node ./scripts/reset-project.js",
     "locales:compile": "lingui compile --typescript",
     "locales:extract": "lingui extract",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",
+    "start-new": "EXPO_PUBLIC_CACHE_KEY=$(date +%s) expo start",
     "reset-project": "node ./scripts/reset-project.js",
     "locales:compile": "lingui compile --typescript",
     "locales:extract": "lingui extract",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",
-    "start-new": "EXPO_PUBLIC_CACHE_KEY=$(date +%s) EXPO_PUBLIC_QUEUE_CACHE_KEY=$(date +%s) expo start",
+    "start-new": "EXPO_PUBLIC_CACHE_KEY=$(date +%s) EXPO_PUBLIC_ACTIVE_QUEUE_CACHE_KEY=$(date +%s) EXPO_PUBLIC_COMPLETED_QUEUE_CACHE_KEY=$(date +%s) EXPO_PUBLIC_BATCH_CACHE_KEY=$(date +%s) expo start",
     "reset-project": "node ./scripts/reset-project.js",
     "locales:compile": "lingui compile --typescript",
     "locales:extract": "lingui extract",


### PR DESCRIPTION
I've added a README update to setup the EXPO_PUBLIC_API_URL variable and the new start command to start expo with a clear cashe. We need EXPO_PUBLIC_CACHE_KEY to start the app, otherwise it complains (https://github.com/Enaleia/mobile/blob/9a0e9b9f9916fea5855edf7139914e6b59db1dea/utils/storage.ts#L9) that it's missing and doesn't start correctly.