### PR TITLE
feat: crypto compatibility layer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+// Polyfill for Buffer
+import { Buffer } from 'buffer'
+global.Buffer = Buffer
+
+// Polyfill for crypto.getRandomValues
+import 'react-native-get-random-values'
+
+// Run the app
+import 'expo-router/entry'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enaleia",
-  "main": "expo-router/entry",
+  "main": "index",
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",
@@ -14,6 +14,10 @@
     "lint": "expo lint",
     "build:icons": "node scripts/convert-svg.js",
     "prebuild": "pnpm build:icons"
+  },
+  "engines": {
+    "node": "22.0.0",
+    "yarn": "1.22.22"
   },
   "jest": {
     "preset": "jest-expo"
@@ -35,7 +39,8 @@
     "@tanstack/react-query": "^5.67.2",
     "@tanstack/react-query-persist-client": "^5.67.2",
     "@tanstack/zod-form-adapter": "^0.33.0",
-    "eas-lib": "^0.1.9",
+    "buffer": "^6.0.3",
+    "eas-lib": "^0.1.10",
     "expo": "~52.0.37",
     "expo-background-fetch": "~13.0.5",
     "expo-battery": "~9.0.2",
@@ -62,6 +67,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.76.7",
     "react-native-gesture-handler": "~2.20.2",
+    "react-native-get-random-values": "^1.11.0",
     "react-native-reanimated": "~3.16.7",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "4.4.0",


### PR DESCRIPTION
This patch introcudes the updates that makes the eas-lib compatible with the mobile supported dependencies. Namely, buffer, crypto primitives and get-random-values are not supported on the specific JS runtime engine.

To apply this changes one needs to:
 - run `npx pod-install` to get react-native get-random-values pod
 - run `yarn ios | android` to compile the native libs into the native implementation
 - use eas-lib

Btw., one needs to run `pnpm i` after merging this branch. I did not push the pnpm-lock.yaml file, since it seems pretty stale - normally each PR owner adding a dependency should also push lock file updates.

To use eas-lib check [eas-lib/examples](https://github.com/Enaleia/eas-lib/tree/main/examples) or use this quick example:
```js
import { EAS } from "eas-lib"

const schema = '...
const schemaUID = '...'
const providerUrl = 'https://purple-frosty-orb.optimism-sepolia.quiknode.pro/aad424a10b06bf69795d7d8abd05b008f7d4c98c'
const privateKey = '...'

const eas = new EAS(providerUrl, privateKey, schema, schemaUID)
const data = {
  ...
}

async function performAttestation() {
  try {
    console.log("starting attestation")
    const uid = await eas.attest(body)
    console.log('EAS Response:', uid)
  } catch (error) {
    console.error('EAS Error:', error)
  }
}

performAttestation();
```